### PR TITLE
stick to golang 1.15

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1:15 as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3
 RUN go get -u -d github.com/magefile/mage && \

--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1:15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3
 RUN go get -u -d github.com/magefile/mage && \

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3
 RUN go get -u -d github.com/magefile/mage && \

--- a/functionbeat/Dockerfile
+++ b/functionbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3
 RUN go get -u -d github.com/magefile/mage && \

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3
 RUN go get -u -d github.com/magefile/mage && \

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3 libsystemd-dev
 RUN go get -u -d github.com/magefile/mage && \

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3
 RUN go get -u -d github.com/magefile/mage && \

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.15 as builder
 ARG BEATSVERSION=master
 RUN apt-get -y update && apt-get -y --no-install-recommends install python3 libpcap-dev
 RUN go get -u -d github.com/magefile/mage && \


### PR DESCRIPTION
Stick to golang version 1.15 as a quick workaround for magefile/mage#339 .

Golang has support for the last 2 major releases (1.16 and 1.15).