### PR TITLE
change installation path to /usr/share/<beatname>

### DIFF
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -12,8 +12,8 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/auditbeat/ && \
 
 FROM centos:8
 RUN useradd --no-create-home --system beats && mkdir /usr/share/auditbeat && chown beats:beats /usr/share/auditbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/auditbeat /usr/share/auditbeat/auditbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/build/kibana/ /usr/share/auditbeat/kibana/
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/auditbeat/auditbeat /usr/share/auditbeat/auditbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/auditbeat/build/kibana/ /usr/share/auditbeat/kibana/
 WORKDIR /usr/share/auditbeat
 CMD ["/usr/share/auditbeat/auditbeat", "-e"]
 USER beats

--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -11,9 +11,9 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/auditbeat/ && \
     mage dashboards
 
 FROM centos:8
-RUN useradd --no-create-home --system beats && mkdir /beats && chown beats:beats /beats
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/auditbeat/auditbeat /beats/auditbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/auditbeat/build/kibana/ /beats/kibana/
-WORKDIR /beats
-ENTRYPOINT ["/beats/auditbeat", "-e"]
+RUN useradd --no-create-home --system beats && mkdir /usr/share/auditbeat && chown beats:beats /usr/share/auditbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/auditbeat/auditbeat /usr/share/auditbeat/auditbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/auditbeat/build/kibana/ /usr/share/auditbeat/kibana/
+WORKDIR /usr/share/auditbeat
+CMD ["/usr/share/auditbeat/auditbeat", "-e"]
 USER beats

--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -12,8 +12,8 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/auditbeat/ && \
 
 FROM centos:8
 RUN useradd --no-create-home --system beats && mkdir /usr/share/auditbeat && chown beats:beats /usr/share/auditbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/auditbeat/auditbeat /usr/share/auditbeat/auditbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/auditbeat/build/kibana/ /usr/share/auditbeat/kibana/
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/auditbeat /usr/share/auditbeat/auditbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/usr/share/auditbeat/build/kibana/ /usr/share/auditbeat/kibana/
 WORKDIR /usr/share/auditbeat
 CMD ["/usr/share/auditbeat/auditbeat", "-e"]
 USER beats

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -11,10 +11,10 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/filebeat/ && \
     mage dashboards
 
 FROM centos:8
-RUN useradd --no-create-home --system beats && mkdir /beats && chown beats:beats /beats
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/filebeat/filebeat /beats/filebeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/filebeat/modules.d/ /beats/modules.d/
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/filebeat/build/kibana/ /beats/kibana/
-WORKDIR /beats
-ENTRYPOINT ["/beats/filebeat", "-e"]
+RUN useradd --no-create-home --system beats && mkdir /usr/share/filebeat && chown beats:beats /usr/share/filebeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/filebeat/filebeat /usr/share/filebeat/filebeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/filebeat/modules.d/ /usr/share/filebeat/modules.d/
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/filebeat/build/kibana/ /usr/share/filebeat/kibana/
+WORKDIR /usr/share/filebeat
+CMD ["/usr/share/filebeat/filebeat", "-e"]
 USER beats

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -10,10 +10,8 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/heartbeat/ && \
     mage build
 
 FROM centos:8
-RUN useradd --no-create-home --system beats && mkdir /beats && chown beats:beats /beats
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/heartbeat/heartbeat /beats/heartbeat
-#COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/heartbeat/modules.d/ /beats/modules.d/
-#COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/heartbeat/build/kibana/ /beats/kibana/
-WORKDIR /beats
-ENTRYPOINT ["/beats/heartbeat", "-e"]
+RUN useradd --no-create-home --system beats && mkdir /usr/share/heartbeat/ && chown beats:beats /usr/share/heartbeat/
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/heartbeat/heartbeat /usr/share/heartbeat/heartbeat
+WORKDIR /usr/share/heartbeat/
+ENTRYPOINT ["/usr/share/heartbeat/heartbeat", "-e"]
 USER beats

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -10,8 +10,8 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/journalbeat/ && \
     mage build
 
 FROM centos:8
-RUN useradd --no-create-home --system beats && mkdir /beats && chown beats:beats /beats
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/journalbeat/journalbeat /beats/journalbeat
-WORKDIR /beats
-ENTRYPOINT ["/beats/journalbeat", "-e"]
+RUN useradd --no-create-home --system beats && mkdir /usr/share/journalbeat && chown beats:beats /usr/share/journalbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/journalbeat/journalbeat /usr/share/journalbeat/journalbeat
+WORKDIR /usr/share/journalbeat/
+CMD ["/usr/share/journalbeat/journalbeat", "-e"]
 USER beats

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -11,10 +11,10 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/metricbeat/ && \
     mage dashboards
 
 FROM centos:8
-RUN useradd --no-create-home --system beats && mkdir /beats && chown beats:beats /beats
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/metricbeat/metricbeat /beats/metricbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/metricbeat/modules.d/ /beats/modules.d/
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/metricbeat/build/kibana/ /beats/kibana/
-WORKDIR /beats
-ENTRYPOINT ["/beats/metricbeat", "-e"]
+RUN useradd --no-create-home --system beats && mkdir /usr/share/metricbeat && chown beats:beats /usr/share/metricbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/metricbeat/metricbeat /usr/share/metricbeat/metricbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/metricbeat/modules.d/ /usr/share/metricbeat/modules.d/
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/metricbeat/build/kibana/ /usr/share/metricbeat/kibana/
+WORKDIR /usr/share/metricbeat
+CMD ["/usr/share/metricbeat/metricbeat", "-e"]
 USER beats

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -12,9 +12,9 @@ RUN cd ${GOPATH}/src/github.com/elastic/beats/packetbeat/ && \
 
 FROM debian:10
 RUN apt-get -y update && apt-get -y --no-install-recommends install libpcap-dev
-RUN useradd --no-create-home --system beats && mkdir /beats && chown beats:beats /beats
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/packetbeat/packetbeat /beats/packetbeat
-COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/packetbeat/build/kibana/ /beats/kibana/
-WORKDIR /beats
-ENTRYPOINT ["/beats/packetbeat", "-e"]
+RUN useradd --no-create-home --system beats && mkdir /usr/share/packetbeat && chown beats:beats /usr/share/packetbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/packetbeat/packetbeat /usr/share/packetbeat/packetbeat
+COPY --from=builder --chown=beats:beats /go/src/github.com/elastic/beats/packetbeat/build/kibana/ /usr/share/packetbeat/kibana/
+WORKDIR /usr/share/packetbeat
+CMD ["/usr/share/packetbeat/packetbeat", "-e"]
 USER beats


### PR DESCRIPTION
All installations provided by elastic do install the beats under /usr/share/<beatname> . Let's keep it that way.